### PR TITLE
Fixed Windows ppx executable not being found without extension

### DIFF
--- a/.github/workflows/scripts/copy-binaries.js
+++ b/.github/workflows/scripts/copy-binaries.js
@@ -32,17 +32,14 @@ if (!supported) {
 
 }
 
-if (platform === "win") {
   if (!fs.existsSync("ppx.exe")) {
     copyFileSync(filename, "ppx.exe");
     fs.chmodSync("ppx.exe", 0755);
   }
-} else {
   if (!fs.existsSync("ppx")) {
     copyFileSync(filename, "ppx");
     fs.chmodSync("ppx", 0755);
   }
-}
 
 function copyFileSync(source, dest) {
   if (typeof fs.copyFileSync === "function") {


### PR DESCRIPTION
Creates a copy of the executable on install, one with .exe extension and one without, across all platforms. This allows Windows environments to use Linux bsconfigs without changing it.